### PR TITLE
endret cookie-endepunkt i mock-alt-api

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -49,7 +49,7 @@ export const Login = () => {
         if (!isLoginSession(params)) {
             queryString = '&redirect=' + redirect;
         }
-        window.location.href = `${getMockAltApiURL()}/login/cookie?subject=${fnr}${queryString}`;
+        window.location.href = `${getMockAltApiURL()}/login/cookie?subject=${fnr}&issuerId=selvbetjening&audience=someaudience${queryString}`;
     };
 
     return (

--- a/src/pages/person/PersonMockData.tsx
+++ b/src/pages/person/PersonMockData.tsx
@@ -337,7 +337,7 @@ export const PersonMockData = () => {
                     dispatchAppStatus({ type: 'success' });
 
                     if (isLoginSession(params)) {
-                        window.location.href = `${getMockAltApiURL()}/login/cookie?subject=${fnr}${addParams(
+                        window.location.href = `${getMockAltApiURL()}/login/cookie?subject=${fnr}&issuerId=selvbetjening&audience=someaudience${addParams(
                             params,
                             '&'
                         )}`;


### PR DESCRIPTION
legger til issuerId og dummy audience som queryparams